### PR TITLE
Make describeMismatchSafely Nullsafe

### DIFF
--- a/src/main/java/com/github/grantwest/eventually/EventuallyLambdaMatcher.java
+++ b/src/main/java/com/github/grantwest/eventually/EventuallyLambdaMatcher.java
@@ -50,6 +50,6 @@ public class EventuallyLambdaMatcher<T> extends TypeSafeMatcher<Supplier<T>> {
 
     @Override
     public void describeMismatchSafely(Supplier<T> lambda, Description mismatchDescription) {
-        mismatchDescription.appendText(val.toString());
+        mismatchDescription.appendText(String.valueOf(val));
     }
 }


### PR DESCRIPTION
If val is null, describeMismatchSafely will throw an exception.